### PR TITLE
Javascript location customization

### DIFF
--- a/src/KristofferStrube.Blazor.FileAPI/BaseJSWrapper.cs
+++ b/src/KristofferStrube.Blazor.FileAPI/BaseJSWrapper.cs
@@ -15,7 +15,7 @@ public abstract class BaseJSWrapper : IAsyncDisposable
     /// <param name="jSReference">A JS reference to an existing JS instance that should be wrapped.</param>
     internal BaseJSWrapper(IJSRuntime jSRuntime, IJSObjectReference jSReference)
     {
-        helperTask = new(jSRuntime.GetHelperAsync);
+        helperTask = new(() => jSRuntime.GetHelperAsync());
         JSReference = jSReference;
         this.jSRuntime = jSRuntime;
     }

--- a/src/KristofferStrube.Blazor.FileAPI/Extensions/IJSRuntimeExtensions.cs
+++ b/src/KristofferStrube.Blazor.FileAPI/Extensions/IJSRuntimeExtensions.cs
@@ -1,17 +1,20 @@
-﻿using Microsoft.JSInterop;
+﻿using KristofferStrube.Blazor.FileAPI.Options;
+using Microsoft.JSInterop;
 
 namespace KristofferStrube.Blazor.FileAPI;
 
 internal static class IJSRuntimeExtensions
 {
-    internal static async Task<IJSObjectReference> GetHelperAsync(this IJSRuntime jSRuntime)
+    internal static async Task<IJSObjectReference> GetHelperAsync(this IJSRuntime jSRuntime, FileApiOptions? options = null)
     {
+        options ??= FileApiOptions.DefaultInstance;
         return await jSRuntime.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/KristofferStrube.Blazor.FileAPI/KristofferStrube.Blazor.FileAPI.js");
+            "import", options.FullScriptPath);
     }
-    internal static async Task<IJSInProcessObjectReference> GetInProcessHelperAsync(this IJSRuntime jSRuntime)
+    internal static async Task<IJSInProcessObjectReference> GetInProcessHelperAsync(this IJSRuntime jSRuntime, FileApiOptions? options = null)
     {
+        options ??= FileApiOptions.DefaultInstance;
         return await jSRuntime.InvokeAsync<IJSInProcessObjectReference>(
-            "import", "./_content/KristofferStrube.Blazor.FileAPI/KristofferStrube.Blazor.FileAPI.js");
+            "import", options.FullScriptPath);
     }
 }

--- a/src/KristofferStrube.Blazor.FileAPI/Extensions/IServiceCollectionExtensions.cs
+++ b/src/KristofferStrube.Blazor.FileAPI/Extensions/IServiceCollectionExtensions.cs
@@ -1,17 +1,28 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using KristofferStrube.Blazor.FileAPI.Options;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 
 namespace KristofferStrube.Blazor.FileAPI;
 
 public static class IServiceCollectionExtensions
 {
-    public static IServiceCollection AddURLService(this IServiceCollection serviceCollection)
+    public static IServiceCollection AddURLService(this IServiceCollection serviceCollection, Action<FileApiOptions>? configure)
     {
+        serviceCollection.ConfigureFaOptions(configure);
         return serviceCollection.AddScoped<IURLService, URLService>();
     }
 
-    public static IServiceCollection AddURLServiceInProcess(this IServiceCollection serviceCollection)
+    public static IServiceCollection AddURLServiceInProcess(this IServiceCollection serviceCollection, Action<FileApiOptions>? configure)
     {
+        serviceCollection.ConfigureFaOptions(configure);
         return serviceCollection.AddScoped<IURLServiceInProcess>(sp => new URLServiceInProcess((IJSInProcessRuntime)sp.GetRequiredService<IJSRuntime>()));
+    }
+
+    private static void ConfigureFaOptions(this IServiceCollection services, Action<FileApiOptions>? configure)
+    {
+        if (configure is null) return;
+
+        services.Configure(configure);
+        configure(FileApiOptions.DefaultInstance);
     }
 }

--- a/src/KristofferStrube.Blazor.FileAPI/Options/FileApiOptions.cs
+++ b/src/KristofferStrube.Blazor.FileAPI/Options/FileApiOptions.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+
+namespace KristofferStrube.Blazor.FileAPI.Options;
+
+public class FileApiOptions()
+{
+    public const string DefaultBasePath = "./_content/";
+    public static readonly string DefaultNamespace = Assembly.GetExecutingAssembly().GetName().Name ?? "KristofferStrube.Blazor.FileAPI";
+    public static readonly string DefaultScriptPath = $"{DefaultNamespace}/{DefaultNamespace}.js";
+
+    public string BasePath { get; set; } = DefaultBasePath;
+    public string ScriptPath { get; set; } = DefaultScriptPath;
+
+    public string FullScriptPath => Path.Combine(this.BasePath, this.ScriptPath);
+
+    internal static FileApiOptions DefaultInstance = new();
+
+}


### PR DESCRIPTION
Following the pattern of other libraries from this author added support for settings the customization of the location of the javascript file.

This will allow to configure it on the Program.cs file:

`services.AddURLService(c => { c.BasePath = "/_content/"; });`